### PR TITLE
Fix fastapi dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.6.1"
-fastapi = "^0.63.0"
+fastapi = ">=0.63.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
Hey,

Thanks for the nifty little package! The current dependency constraint translates to `>=0.63.0,<0.64.0` when the wheel is built which I'm guessing is not what you intended as it means it can't be installed in a project that's using a newer version of FastAPI (0.68.0) when using Poetry.

The workaround for now is to just install the package manually using `pip` but it'd be nice to keep everything inside the Poetry ecosystem.

Thanks!