### PR TITLE
Update README.md to match the package behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ app.add_api_route("/health", health([is_database_online]))
 
 The `health()` method receives the following parameters:
 - `conditions`: A list of callables that represents the conditions of your API, it can return either `bool` or a `dict`.
-- `success_output`: An optional callable which receives `**kwargs` and returns a dictionary that will be the content response of a successful health call.
+- `success_output`: An optional callable which receives the `conditions` results and returns a dictionary that will be the content response of a successful health call.
 - `failure_output`: An optional callable analogous to `success_output` for failure scenarios.
 - `success_status`: An integer that overwrites the default status (200) in case of success.
 - `failure_status`: An integer that overwrites the default status (503) in case of failure.

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ app.add_api_route("/health", health([is_database_online]))
 
 The `health()` method receives the following parameters:
 - `conditions`: A list of callables that represents the conditions of your API, it can return either `bool` or a `dict`.
-- `success_output`: An optional dictionary that will be the content response of a successful health call.
-- `failure_output`: An optional dictionary analogous to `success_output` for failure scenarios.
+- `success_output`: An optional callable which receives `**kwargs` and returns a dictionary that will be the content response of a successful health call.
+- `failure_output`: An optional callable analogous to `success_output` for failure scenarios.
 - `success_status`: An integer that overwrites the default status (200) in case of success.
 - `failure_status`: An integer that overwrites the default status (503) in case of failure.
 


### PR DESCRIPTION
According to the tests and inspection that I did to the package, if you pass a dictionary to the `success_output` or the `failure_output` parameters (as their description in the README says), the code will fail. 

This due to the fact that the parameter will be used later like this `output = await handler(**dependencies), like a callable.

Something like this will work:
```py
async def success(**kwargs):
    return {"response": "everything ok"}


async def failure(**kwargs):
    return {"response": "everything not ok"}


app.add_api_route(
    "/health",
    health(
        [is_database_online, return_false],
        success_handler=success,
        failure_handler=failure,
    ),
)
```

Something like this wont:
```py
app.add_api_route(
    "/health",
    health(
        [is_database_online, return_false],
        success_handler={"response": "everything ok"},
        failure_handler={"response": "everything not ok"},
    ),
)
```

It will raise a TypeError:
```console
TypeError: 'dict' object is not callable
```