### PR TITLE
Add a new behavior to the default handler

### DIFF
--- a/fastapi_health/route.py
+++ b/fastapi_health/route.py
@@ -8,9 +8,11 @@ from fastapi.responses import JSONResponse
 
 async def default_handler(**kwargs) -> Dict[str, Any]:
     output = {}
-    for value in kwargs.values():
+    for key, value in kwargs.items():
         if isinstance(value, dict):
             output.update(value)
+        else:
+            output.update({key: value})
     return output
 
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -110,7 +110,11 @@ def test_hybrid():
     with TestClient(app) as client:
         res = client.get("/health")
         assert res.status_code == 503
-        assert res.json() == {"banana": "yes"}
+        assert res.json() == {
+            "healthy_dict": True,
+            "banana": "yes",
+            "sick": False,
+        }
 
 
 def test_success_handler():
@@ -125,7 +129,8 @@ def test_success_handler():
 
     app = FastAPI()
     app.add_api_route(
-        "/health", health([healthy, another_healthy], success_handler=success_handler)
+        "/health",
+        health([healthy, another_healthy], success_handler=success_handler),
     )
     with TestClient(app) as client:
         res = client.get("/health")


### PR DESCRIPTION
# What?
Add a new behavior to the default handler

If the dependency doesn't return a dict, the handler will return the
name of the dependency plus its value.

# Why?
If we run the example in the README.md, we get the following response:
`{}` and status `200`

That empty dictionary may not be that clear of what's going on.

And I think that is even more notorious if we change the example to this:
```py
from fastapi import FastAPI, Depends
from fastapi_health import health


def get_session():
    return False


def is_database_online(session: bool = Depends(get_session)):
    return session


app = FastAPI()
app.add_api_route("/health", health([is_database_online]))
```
If we run that we get `{}`and a `503` response.

I think it may be clearer if the response would be `{"is_database_online":false}` (using the default handler)

# How?
Modify the `default_handler`:
```py
async def default_handler(**kwargs) -> Dict[str, Any]:
    output = {}
    for key, value in kwargs.items():
        if isinstance(value, dict):
            output.update(value)
        else:
            output.update({key: value})
    return output
```
If then we run the README.md example we get:

```
{"is_database_online":true}
```

---
This is just a suggestion! I'm loving this repo ☺️
What do you think? Maybe we could even add a flag to indicate if we want this behavior or not