### PR TITLE
📌 Pin Pydantic to V1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 license = "MIT"
 requires-python = ">=3.8"
-dependencies = ["fastapi>=0.85.0"]
+dependencies = ["fastapi>=0.85.0", "pydantic<=2.0"]
 optional-dependencies = {}
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 license = "MIT"
 requires-python = ">=3.8"
-dependencies = ["fastapi>=0.85.0", "pydantic<=2.0"]
+dependencies = ["fastapi>=0.85.0", "pydantic<2.0"]
 optional-dependencies = {}
 
 [project.urls]


### PR DESCRIPTION
Closes #30

Disable Pydantic v2 support until explicit support is added. Since there is currently no limit on the upper bound of Pydantic version supported, the CI fails due to backwards incompatible changes introduced in Pydantic v2. An example of this can be seen in https://github.com/Kludex/fastapi-health/pull/29.